### PR TITLE
Add register entires for SM and CM MCU FW inventory checks

### DIFF
--- a/address_table/modules/PL_MEM.xml
+++ b/address_table/modules/PL_MEM.xml
@@ -6,6 +6,16 @@
       <node id="TX" address="0x00000001" permission="rw" parameters="Table=ZYNQ_OS;Row=_3;Column=_4;Status=1;Format=m_1_1_1000_1_0_1;Format=d;" description="Rate of ETH0_TX at kB/sec"/>
     </node>
   </node>
+  <node id="INVENTORY" address="0x000007C0">
+    <node id="SM_FW" address="0x0">
+      <node id="DB_MATCH" address="0x0" mask="0x1" permission="rw" parameters="Table=INVENTORY;Row=_3;Column=_4;Format=t_0_No_1_Yes;Status=1" />
+      <node id="IS_LATEST_TAG" address="0x0" mask="0x2" permission="rw" parameters="Table=INVENTORY;Row=_3;Column=_4;Format=t_0_No_1_Yes;Status=1" />
+    </node>
+    <node id="CM_MCU_FW" address="0x1">
+      <node id="DB_MATCH" address="0x0" mask="0x1" permission="rw" parameters="Table=INVENTORY;Row=_3;Column=_4;Format=t_0_No_1_Yes;Status=1" />
+      <node id="IS_LATEST_TAG" address="0x0" mask="0x2" permission="rw" parameters="Table=INVENTORY;Row=_3;Column=_4;Format=t_0_No_1_Yes;Status=1" />
+    </node>
+  </node>
   <node id="SM_POWER" address="0x000007D0">
     <node id="ZYNQ_1V8" address="0x0">
       <node id="V" address="0x0" permission="rw" parameters="Table=SM_Power;Row=_3;Column=Volts;Format=m_1_1_1000_1_0_1;Status=1"/>


### PR DESCRIPTION
This PR adds register entries to `SLAVE_I2C.xml` for the SM and CM MCU FW inventory checks.

@dgastler please let me know if you think this looks okay to you, we can merge it or wait for more changes if we want to add more registers for checking in the future. Thanks!