### PR TITLE
Add registers for IPMC FW, UID and shelf/slot ID

### DIFF
--- a/address_table/modules/SLAVE_I2C.xml
+++ b/address_table/modules/SLAVE_I2C.xml
@@ -138,6 +138,16 @@
     <!-- <node id="E"  address="0xE" permission="rw"/> -->
     <!-- <node id="F"  address="0xF" permission="rw"/> -->
   </node>
+  <node id="S6" address ="0x50">
+    <node id="SITE_NUMBER" permission="r" address="0x0" />
+    <node id="SHELF_ID"    permission="r" address="0x1" mode="incremental" size="0x5" parameters="Format=c;">
+      <node id="WORD_1" permission="r" address="0x0" parameters="Format=c;" />
+      <node id="WORD_2" permission="r" address="0x1" parameters="Format=c;" />
+      <node id="WORD_3" permission="r" address="0x2" parameters="Format=c;" />
+      <node id="WORD_4" permission="r" address="0x3" parameters="Format=c;" />
+      <node id="WORD_5" permission="r" address="0x4" parameters="Format=c;" />
+    </node>
+  </node>
   <!-- <node id="S6" address ="0x50"> -->
   <!--   <node id="0"  address="0x0" permission="rw"/> -->
   <!--   <node id="1"  address="0x1" permission="rw"/> -->

--- a/address_table/modules/SLAVE_I2C.xml
+++ b/address_table/modules/SLAVE_I2C.xml
@@ -210,16 +210,16 @@
 	<node id="BYTE_3"      address="0x0"        permission="r" mask="0xFF000000" description="IPMC IP adder byte 4"/>
     </node>      
     <node id="IPMC_FW" address="0x4">
-  <node id="GIT_HASH_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC FW hash byte 1"/>
-  <node id="GIT_HASH_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC FW hash byte 2"/>
-  <node id="GIT_HASH_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC FW hash byte 3"/>
-  <node id="GIT_HASH_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC FW hash byte 4"/>
+      <node id="GIT_HASH_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC FW hash byte 1"/>
+      <node id="GIT_HASH_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC FW hash byte 2"/>
+      <node id="GIT_HASH_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC FW hash byte 3"/>
+      <node id="GIT_HASH_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC FW hash byte 4"/>
     </node>
     <node id="IPMC_UID" address="0x5">
-  <node id="BYTE_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC UID hash byte 1"/>
-  <node id="BYTE_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC UID hash byte 2"/>
-  <node id="BYTE_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC UID hash byte 3"/>
-  <node id="BYTE_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC UID hash byte 4"/>
+      <node id="BYTE_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC UID hash byte 1"/>
+      <node id="BYTE_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC UID hash byte 2"/>
+      <node id="BYTE_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC UID hash byte 3"/>
+      <node id="BYTE_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC UID hash byte 4"/>
     </node>
     <!-- <node id="3"  address="0x3" permission="rw"/> -->
     <!-- <node id="4"  address="0x4" permission="rw"/> -->

--- a/address_table/modules/SLAVE_I2C.xml
+++ b/address_table/modules/SLAVE_I2C.xml
@@ -209,6 +209,18 @@
 	<node id="BYTE_2"      address="0x0"        permission="r" mask="0x00FF0000" description="IPMC IP adder byte 3"/>
 	<node id="BYTE_3"      address="0x0"        permission="r" mask="0xFF000000" description="IPMC IP adder byte 4"/>
     </node>      
+    <node id="IPMC_FW" address="0x4">
+  <node id="GIT_HASH_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC FW hash byte 1"/>
+  <node id="GIT_HASH_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC FW hash byte 2"/>
+  <node id="GIT_HASH_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC FW hash byte 3"/>
+  <node id="GIT_HASH_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC FW hash byte 4"/>
+    </node>
+    <node id="IPMC_UID" address="0x5">
+  <node id="BYTE_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC UID hash byte 1"/>
+  <node id="BYTE_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC UID hash byte 2"/>
+  <node id="BYTE_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC UID hash byte 3"/>
+  <node id="BYTE_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC UID hash byte 4"/>
+    </node>
     <!-- <node id="3"  address="0x3" permission="rw"/> -->
     <!-- <node id="4"  address="0x4" permission="rw"/> -->
     <!-- <node id="5"  address="0x5" permission="rw"/> -->

--- a/address_table/modules/SLAVE_I2C.xml
+++ b/address_table/modules/SLAVE_I2C.xml
@@ -139,8 +139,8 @@
     <!-- <node id="F"  address="0xF" permission="rw"/> -->
   </node>
   <node id="S6" address ="0x50">
-    <node id="SITE_NUMBER" permission="r" address="0x0" />
-    <node id="SHELF_ID"    permission="r" address="0x1" mode="incremental" size="0x5" parameters="Format=c;">
+    <node id="SITE_NUMBER" permission="r" address="0x0" description="Physical site number of the blade." />
+    <node id="SHELF_ID"    permission="r" address="0x1" mode="incremental" size="0x5" parameters="Format=c;" description="20-byte shelf ID.">
       <node id="WORD_1" permission="r" address="0x0" parameters="Format=c;" />
       <node id="WORD_2" permission="r" address="0x1" parameters="Format=c;" />
       <node id="WORD_3" permission="r" address="0x2" parameters="Format=c;" />
@@ -219,13 +219,13 @@
 	<node id="BYTE_2"      address="0x0"        permission="r" mask="0x00FF0000" description="IPMC IP adder byte 3"/>
 	<node id="BYTE_3"      address="0x0"        permission="r" mask="0xFF000000" description="IPMC IP adder byte 4"/>
     </node>      
-    <node id="IPMC_FW" address="0x4">
+    <node id="IPMC_FW" address="0x4" description="32-bit git hash for the IPMC FW.">
       <node id="GIT_HASH_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC FW hash byte 1"/>
       <node id="GIT_HASH_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC FW hash byte 2"/>
       <node id="GIT_HASH_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC FW hash byte 3"/>
       <node id="GIT_HASH_3" address="0x0"        permission="r" mask="0xFF000000" description="IPMC FW hash byte 4"/>
     </node>
-    <node id="IPMC_UID" address="0x5">
+    <node id="IPMC_UID" address="0x5" description="Unique 32-bit identifier for the installed IPMC.">
       <node id="BYTE_0" address="0x0"        permission="r" mask="0x000000FF" description="IPMC UID hash byte 1"/>
       <node id="BYTE_1" address="0x0"        permission="r" mask="0x0000FF00" description="IPMC UID hash byte 2"/>
       <node id="BYTE_2" address="0x0"        permission="r" mask="0x00FF0000" description="IPMC UID hash byte 3"/>


### PR DESCRIPTION
This PR adds the following registers to `SLAVE_I2C.xml`:

* `S6.SITE_NUMBER`: Physical site number of the board
* `S6.SHELF_ID`: 5-word shelf ID obtained from shelf manager
* `S8.IPMC_FW`: 32-bit git hash for the IPMC FW
* `S8.IPMC_UID`: 32-bit unique identifier for the IPMC